### PR TITLE
fix the print string formatting

### DIFF
--- a/examples/lsm303dlh_mag_compass.py
+++ b/examples/lsm303dlh_mag_compass.py
@@ -22,5 +22,5 @@ def get_heading(_sensor):
 
 
 while True:
-    print("heading: {.2f} degrees".format(get_heading(sensor)))
+    print("heading: {:.2f} degrees".format(get_heading(sensor)))
     time.sleep(0.2)


### PR DESCRIPTION
Somehow I dropped a `:` from the string format causing a KeyError, this change adds the missing one to resolve the error.