### PR TITLE
typo in __repo__ url

### DIFF
--- a/adafruit_lsm303dlh_mag.py
+++ b/adafruit_lsm303dlh_mag.py
@@ -37,7 +37,7 @@ from micropython import const
 from adafruit_bus_device.i2c_device import I2CDevice
 
 __version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_LSM303DHL_Mag.git"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_LSM303DLH_Mag.git"
 
 _ADDRESS_MAG = const(0x1E)  # (0x3C >> 1)       // 0011110x
 _ID = const(0xD4)  # (0b11010100)


### PR DESCRIPTION
Adafruit_CircuitPython_LSM303DHL_Mag should be Adafruit_CircuitPython_LSM303DLH_Mag

@makermelissa  One more __repo__ url typo