### PR TITLE
Bug: returning magnetometer values in wrong order | Fixed incorrect return order in _raw_magnetic.

### DIFF
--- a/adafruit_lsm303dlh_mag.py
+++ b/adafruit_lsm303dlh_mag.py
@@ -48,10 +48,10 @@ _REG_MAG_CRB_REG_M = const(0x01)
 _REG_MAG_MR_REG_M = const(0x02)
 _REG_MAG_OUT_X_H_M = const(0x03)
 _REG_MAG_OUT_X_L_M = const(0x04)
-_REG_MAG_OUT_Z_H_M = const(0x05)
-_REG_MAG_OUT_Z_L_M = const(0x06)
-_REG_MAG_OUT_Y_H_M = const(0x07)
-_REG_MAG_OUT_Y_L_M = const(0x08)
+_REG_MAG_OUT_Y_H_M = const(0x05)
+_REG_MAG_OUT_Y_L_M = const(0x06)
+_REG_MAG_OUT_Z_H_M = const(0x07)
+_REG_MAG_OUT_Z_L_M = const(0x08)
 _REG_MAG_SR_REG_M = const(0x09)
 _REG_MAG_IRA_REG_M = const(0x0A)
 _REG_MAG_IRB_REG_M = const(0x0B)
@@ -139,7 +139,7 @@ class LSM303DLH_Mag:
         """
         self._read_bytes(self._mag_device, _REG_MAG_OUT_X_H_M, 6, self._BUFFER)
         raw_values = struct.unpack_from(">hhh", self._BUFFER[0:6])
-        return (raw_values[0], raw_values[2], raw_values[1])
+        return (raw_values[0], raw_values[1], raw_values[2])
 
     @property
     def magnetic(self):


### PR DESCRIPTION
Hi,
Just noticed the values that are being returned from [`_raw_magnetic`](https://github.com/adafruit/Adafruit_CircuitPython_LSM303DLH_Mag/blob/6d2fec3907ac40dadd0ca3e9382b52250e7d74a0/adafruit_lsm303dlh_mag.py#L136) function are in wrong order:
https://github.com/adafruit/Adafruit_CircuitPython_LSM303DLH_Mag/blob/6d2fec3907ac40dadd0ca3e9382b52250e7d74a0/adafruit_lsm303dlh_mag.py#L142
According to the datasheet of LSM303DLH, the register `0x03-0x04` is for X channel, `0x05-0x06` for Y channel and `0x07-0x08` for Z channel.
![image](https://user-images.githubusercontent.com/17906294/192110449-badc0f16-5db4-4397-8162-3e84595b45b4.png)

The address of the registers Y and Z are also interchanged in the declaration, which could have given the correct output, but it looks like the library is fetching readings from all 6 registers simultaneously and not though the defined addresses in line 51 to 54:
https://github.com/adafruit/Adafruit_CircuitPython_LSM303DLH_Mag/blob/6d2fec3907ac40dadd0ca3e9382b52250e7d74a0/adafruit_lsm303dlh_mag.py#L140
https://github.com/adafruit/Adafruit_CircuitPython_LSM303DLH_Mag/blob/6d2fec3907ac40dadd0ca3e9382b52250e7d74a0/adafruit_lsm303dlh_mag.py#L49-L54
Hence while returning it is returning in order X,Z,Y.
